### PR TITLE
fix macros creation lua errors

### DIFF
--- a/ZygorGuidesViewer.lua
+++ b/ZygorGuidesViewer.lua
@@ -666,10 +666,10 @@ function me:SetMacroButton(slot, text)
     local macroname = 'ZGV:' .. slot
     local macro = GetMacroIndexByName(macroname)
     if macro == 0 then
-      macro = CreateMacro(macroname, 1, text, 1)
+      macro = CreateMacro(macroname, 1, text, 0)
     end
 
-    macro = EditMacro(macroname, 'ZGV:' .. slot, 1, text, 1)
+    macro = EditMacro(macroname, 'ZGV:' .. slot, 1, text, 0)
   end
 end
 


### PR DESCRIPTION
Fix lua error when my personal macros tab is full and zygor tries to create macros, use general macros tab instead, which had more space.